### PR TITLE
Use launch templates instead of launch configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ custom:
 
     # Whether to create a NAT instance
     createNatInstance: false
+    # When enabled with the above, it will utilize the
+    # [fck-nat](https://fck-nat.dev/) AMI vs. the Amazon AMI's with arm64
+    # t4g.nano instances
+    createNatInstanceFckNat: false
 
     # Whether to create AWS Systems Manager (SSM) Parameters
     createParameters: false

--- a/__tests__/bastion.test.js
+++ b/__tests__/bastion.test.js
@@ -277,7 +277,7 @@ describe('bastion', () => {
       expect.assertions(1);
     });
 
-    it('builds an auto scaling group', () => {
+    it.skip('builds an auto scaling group', () => {
       const expected = {
         BastionAutoScalingGroup: {
           Type: 'AWS::AutoScaling::AutoScalingGroup',

--- a/__tests__/bastion.test.js
+++ b/__tests__/bastion.test.js
@@ -203,7 +203,7 @@ describe('bastion', () => {
   });
 
   describe('#buildBastionLaunchConfiguration', () => {
-    it('builds launch configuration', () => {
+    it.skip('builds launch configuration', () => {
       const expected = {
         BastionLaunchConfiguration: {
           Type: 'AWS::AutoScaling::LaunchConfiguration',
@@ -324,7 +324,7 @@ describe('bastion', () => {
   });
 
   describe('#buildBastion', () => {
-    it('builds the complete bastion host', async () => {
+    it.skip('builds the complete bastion host', async () => {
       const scope = nock('https://checkip.amazonaws.com').get('/').reply(200, '127.0.0.1');
 
       const expected = {

--- a/__tests__/bastion.test.js
+++ b/__tests__/bastion.test.js
@@ -6,7 +6,7 @@ const {
   buildBastionEIP,
   buildBastionIamRole,
   buildBastionInstanceProfile,
-  buildBastionLaunchConfiguration,
+  buildBastionLaunchTemplate,
   buildBastionAutoScalingGroup,
   buildBastionSecurityGroup,
 } = require('../src/bastion');
@@ -203,68 +203,80 @@ describe('bastion', () => {
   });
 
   describe('#buildBastionLaunchConfiguration', () => {
-    it.skip('builds launch configuration', () => {
+    it('builds launch configuration', () => {
       const expected = {
-        BastionLaunchConfiguration: {
-          Type: 'AWS::AutoScaling::LaunchConfiguration',
+        BastionLaunchTemplate: {
+          Type: 'AWS::EC2::LaunchTemplate',
           Properties: {
-            AssociatePublicIpAddress: true,
-            BlockDeviceMappings: [
-              {
-                DeviceName: '/dev/xvda',
-                Ebs: {
-                  VolumeSize: 10,
-                  VolumeType: 'gp3',
-                  DeleteOnTermination: true,
+            LaunchTemplateName: {
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': '${AWS::StackName}-bastion',
+            },
+            LaunchTemplateData: {
+              BlockDeviceMappings: [
+                {
+                  DeviceName: '/dev/xvda',
+                  Ebs: {
+                    VolumeSize: 10,
+                    VolumeType: 'gp3',
+                    DeleteOnTermination: true,
+                  },
+                },
+              ],
+              KeyName: 'MyKey',
+              ImageId: {
+                Ref: 'LatestAmiId',
+              },
+              IamInstanceProfile: {
+                Arn: {
+                  'Fn::GetAtt': ['BastionInstanceProfile', 'Arn'],
                 },
               },
-            ],
-            KeyName: 'MyKey',
-            ImageId: {
-              Ref: 'LatestAmiId',
-            },
-            InstanceMonitoring: false,
-            IamInstanceProfile: {
-              Ref: 'BastionInstanceProfile',
-            },
-            InstanceType: 't2.micro',
-            SecurityGroups: [
-              {
-                Ref: 'BastionSecurityGroup',
-              },
-            ],
-            SpotPrice: '0.0116',
-            UserData: {
-              'Fn::Base64': {
-                'Fn::Join': [
-                  '',
-                  [
-                    '#!/bin/bash -xe\n',
-                    '/usr/bin/yum update -y\n',
-                    '/usr/bin/yum install -y aws-cfn-bootstrap\n',
-                    'EIP_ALLOCATION_ID=',
-                    { 'Fn::GetAtt': ['BastionEIP', 'AllocationId'] },
-                    '\n',
-                    'INSTANCE_ID=`/usr/bin/curl -sq http://169.254.169.254/latest/meta-data/instance-id`\n',
-                    // eslint-disable-next-line no-template-curly-in-string
-                    '/usr/bin/aws ec2 associate-address --instance-id ${INSTANCE_ID} --allocation-id ${EIP_ALLOCATION_ID} --region ',
-                    { Ref: 'AWS::Region' },
-                    '\n',
-                    '/opt/aws/bin/cfn-signal --exit-code 0 --stack ',
-                    { Ref: 'AWS::StackName' },
-                    ' --resource BastionAutoScalingGroup ',
-                    ' --region ',
-                    { Ref: 'AWS::Region' },
-                    '\n',
+              InstanceType: 't2.micro',
+              NetworkInterfaces: [
+                {
+                  AssociatePublicIpAddress: true,
+                  DeviceIndex: 0,
+                  Groups: [
+                    {
+                      Ref: 'BastionSecurityGroup',
+                    },
                   ],
-                ],
+                  DeleteOnTermination: true,
+                },
+              ],
+              UserData: {
+                'Fn::Base64': {
+                  'Fn::Join': [
+                    '',
+                    [
+                      '#!/bin/bash -xe\n',
+                      '/usr/bin/yum update -y\n',
+                      '/usr/bin/yum install -y aws-cfn-bootstrap\n',
+                      'EIP_ALLOCATION_ID=',
+                      { 'Fn::GetAtt': ['BastionEIP', 'AllocationId'] },
+                      '\n',
+                      'INSTANCE_ID=`/usr/bin/curl -sq http://169.254.169.254/latest/meta-data/instance-id`\n',
+                      // eslint-disable-next-line no-template-curly-in-string
+                      '/usr/bin/aws ec2 associate-address --instance-id ${INSTANCE_ID} --allocation-id ${EIP_ALLOCATION_ID} --region ',
+                      { Ref: 'AWS::Region' },
+                      '\n',
+                      '/opt/aws/bin/cfn-signal --exit-code 0 --stack ',
+                      { Ref: 'AWS::StackName' },
+                      ' --resource BastionAutoScalingGroup ',
+                      ' --region ',
+                      { Ref: 'AWS::Region' },
+                      '\n',
+                    ],
+                  ],
+                },
               },
             },
           },
         },
       };
 
-      const actual = buildBastionLaunchConfiguration('MyKey');
+      const actual = buildBastionLaunchTemplate('MyKey');
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });
@@ -277,7 +289,7 @@ describe('bastion', () => {
       expect.assertions(1);
     });
 
-    it.skip('builds an auto scaling group', () => {
+    it('builds an auto scaling group', () => {
       const expected = {
         BastionAutoScalingGroup: {
           Type: 'AWS::AutoScaling::AutoScalingGroup',
@@ -288,8 +300,13 @@ describe('bastion', () => {
             },
           },
           Properties: {
-            LaunchConfigurationName: {
-              Ref: 'BastionLaunchConfiguration',
+            LaunchTemplate: {
+              LaunchTemplateId: {
+                Ref: 'BastionLaunchTemplate',
+              },
+              Version: {
+                'Fn::GetAtt': ['BastionLaunchTemplate', 'LatestVersionNumber'],
+              },
             },
             VPCZoneIdentifier: [
               {
@@ -324,7 +341,7 @@ describe('bastion', () => {
   });
 
   describe('#buildBastion', () => {
-    it.skip('builds the complete bastion host', async () => {
+    it('builds the complete bastion host', async () => {
       const scope = nock('https://checkip.amazonaws.com').get('/').reply(200, '127.0.0.1');
 
       const expected = {
@@ -378,8 +395,13 @@ describe('bastion', () => {
             },
           },
           Properties: {
-            LaunchConfigurationName: {
-              Ref: 'BastionLaunchConfiguration',
+            LaunchTemplate: {
+              LaunchTemplateId: {
+                Ref: 'BastionLaunchTemplate',
+              },
+              Version: {
+                'Fn::GetAtt': ['BastionLaunchTemplate', 'LatestVersionNumber'],
+              },
             },
             VPCZoneIdentifier: [
               {
@@ -405,59 +427,71 @@ describe('bastion', () => {
             ],
           },
         },
-        BastionLaunchConfiguration: {
-          Type: 'AWS::AutoScaling::LaunchConfiguration',
+        BastionLaunchTemplate: {
+          Type: 'AWS::EC2::LaunchTemplate',
           Properties: {
-            AssociatePublicIpAddress: true,
-            BlockDeviceMappings: [
-              {
-                DeviceName: '/dev/xvda',
-                Ebs: {
-                  VolumeSize: 10,
-                  VolumeType: 'gp3',
-                  DeleteOnTermination: true,
+            LaunchTemplateName: {
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': '${AWS::StackName}-bastion',
+            },
+            LaunchTemplateData: {
+              BlockDeviceMappings: [
+                {
+                  DeviceName: '/dev/xvda',
+                  Ebs: {
+                    VolumeSize: 10,
+                    VolumeType: 'gp3',
+                    DeleteOnTermination: true,
+                  },
+                },
+              ],
+              KeyName: 'MyKey',
+              ImageId: {
+                Ref: 'LatestAmiId',
+              },
+              IamInstanceProfile: {
+                Arn: {
+                  'Fn::GetAtt': ['BastionInstanceProfile', 'Arn'],
                 },
               },
-            ],
-            KeyName: 'MyKey',
-            ImageId: {
-              Ref: 'LatestAmiId',
-            },
-            InstanceMonitoring: false,
-            IamInstanceProfile: {
-              Ref: 'BastionInstanceProfile',
-            },
-            InstanceType: 't2.micro',
-            SecurityGroups: [
-              {
-                Ref: 'BastionSecurityGroup',
-              },
-            ],
-            SpotPrice: '0.0116',
-            UserData: {
-              'Fn::Base64': {
-                'Fn::Join': [
-                  '',
-                  [
-                    '#!/bin/bash -xe\n',
-                    '/usr/bin/yum update -y\n',
-                    '/usr/bin/yum install -y aws-cfn-bootstrap\n',
-                    'EIP_ALLOCATION_ID=',
-                    { 'Fn::GetAtt': ['BastionEIP', 'AllocationId'] },
-                    '\n',
-                    'INSTANCE_ID=`/usr/bin/curl -sq http://169.254.169.254/latest/meta-data/instance-id`\n',
-                    // eslint-disable-next-line no-template-curly-in-string
-                    '/usr/bin/aws ec2 associate-address --instance-id ${INSTANCE_ID} --allocation-id ${EIP_ALLOCATION_ID} --region ',
-                    { Ref: 'AWS::Region' },
-                    '\n',
-                    '/opt/aws/bin/cfn-signal --exit-code 0 --stack ',
-                    { Ref: 'AWS::StackName' },
-                    ' --resource BastionAutoScalingGroup ',
-                    ' --region ',
-                    { Ref: 'AWS::Region' },
-                    '\n',
+              InstanceType: 't2.micro',
+              NetworkInterfaces: [
+                {
+                  AssociatePublicIpAddress: true,
+                  DeviceIndex: 0,
+                  Groups: [
+                    {
+                      Ref: 'BastionSecurityGroup',
+                    },
                   ],
-                ],
+                  DeleteOnTermination: true,
+                },
+              ],
+              UserData: {
+                'Fn::Base64': {
+                  'Fn::Join': [
+                    '',
+                    [
+                      '#!/bin/bash -xe\n',
+                      '/usr/bin/yum update -y\n',
+                      '/usr/bin/yum install -y aws-cfn-bootstrap\n',
+                      'EIP_ALLOCATION_ID=',
+                      { 'Fn::GetAtt': ['BastionEIP', 'AllocationId'] },
+                      '\n',
+                      'INSTANCE_ID=`/usr/bin/curl -sq http://169.254.169.254/latest/meta-data/instance-id`\n',
+                      // eslint-disable-next-line no-template-curly-in-string
+                      '/usr/bin/aws ec2 associate-address --instance-id ${INSTANCE_ID} --allocation-id ${EIP_ALLOCATION_ID} --region ',
+                      { Ref: 'AWS::Region' },
+                      '\n',
+                      '/opt/aws/bin/cfn-signal --exit-code 0 --stack ',
+                      { Ref: 'AWS::StackName' },
+                      ' --resource BastionAutoScalingGroup ',
+                      ' --region ',
+                      { Ref: 'AWS::Region' },
+                      '\n',
+                    ],
+                  ],
+                },
               },
             },
           },

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -247,7 +247,7 @@ describe('ServerlessVpcPlugin', () => {
 
       mockHelper('EC2', 'describeImages', mockCallback);
 
-      const actual = await plugin.getImagesByName('test');
+      const actual = await plugin.getImagesByName('test', 'test', 'test');
       expect(actual).toEqual(['ami-test']);
       expect(mockCallback).toHaveBeenCalled();
       expect.assertions(3);

--- a/__tests__/nat_instance.test.js
+++ b/__tests__/nat_instance.test.js
@@ -121,7 +121,68 @@ describe('nat_instance', () => {
 
       const imageId = 'ami-00a9d4a05375b2763';
 
-      const actual = buildNatInstance(imageId, ['us-east-1a', 'us-east-1b']);
+      const actual = buildNatInstance(imageId, 't2.micro', ['us-east-1a', 'us-east-1b']);
+      expect(actual).toEqual(expected);
+      expect.assertions(1);
+    });
+  });
+
+  describe('#buildNatInstance createNatInstanceFckNat', () => {
+    it('builds an EC2 instance', () => {
+      const expected = {
+        NatInstance: {
+          Type: 'AWS::EC2::Instance',
+          DependsOn: 'InternetGatewayAttachment',
+          Properties: {
+            AvailabilityZone: {
+              'Fn::Select': ['0', ['us-east-1a', 'us-east-1b']],
+            },
+            BlockDeviceMappings: [
+              {
+                DeviceName: '/dev/xvda',
+                Ebs: {
+                  VolumeSize: 10,
+                  VolumeType: 'gp2',
+                  DeleteOnTermination: true,
+                },
+              },
+            ],
+            ImageId: 'ami-0d30a34832b46dcae',
+            InstanceType: 't4g.nano',
+            Monitoring: false,
+            NetworkInterfaces: [
+              {
+                AssociatePublicIpAddress: true,
+                DeleteOnTermination: true,
+                Description: 'eth0',
+                DeviceIndex: '0',
+                GroupSet: [
+                  {
+                    Ref: 'NatSecurityGroup',
+                  },
+                ],
+                SubnetId: {
+                  Ref: 'PublicSubnet1',
+                },
+              },
+            ],
+            SourceDestCheck: false,
+            Tags: [
+              {
+                Key: 'Name',
+                Value: {
+                  // eslint-disable-next-line no-template-curly-in-string
+                  'Fn::Sub': '${AWS::StackName}-nat',
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      const imageId = 'ami-0d30a34832b46dcae';
+
+      const actual = buildNatInstance(imageId, 't4g.nano', ['us-east-1a', 'us-east-1b']);
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta4",
+  "version": "1.0.7-beta5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@compassion-technology/serverless-vpc-plugin",
-      "version": "1.0.7-beta4",
+      "version": "1.0.7-beta5",
       "license": "MIT",
       "dependencies": {
         "cidr-split": "0.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta9",
+  "version": "1.0.7-beta10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@compassion-technology/serverless-vpc-plugin",
-      "version": "1.0.7-beta9",
+      "version": "1.0.7-beta10",
       "license": "MIT",
       "dependencies": {
         "cidr-split": "0.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta13",
+  "version": "1.0.7-beta14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@compassion-technology/serverless-vpc-plugin",
-      "version": "1.0.7-beta13",
+      "version": "1.0.7-beta14",
       "license": "MIT",
       "dependencies": {
         "cidr-split": "0.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta8",
+  "version": "1.0.7-beta9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@compassion-technology/serverless-vpc-plugin",
-      "version": "1.0.7-beta8",
+      "version": "1.0.7-beta9",
       "license": "MIT",
       "dependencies": {
         "cidr-split": "0.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta15",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@compassion-technology/serverless-vpc-plugin",
-      "version": "1.0.7-beta15",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "cidr-split": "0.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta14",
+  "version": "1.0.7-beta15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@compassion-technology/serverless-vpc-plugin",
-      "version": "1.0.7-beta14",
+      "version": "1.0.7-beta15",
       "license": "MIT",
       "dependencies": {
         "cidr-split": "0.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta5",
+  "version": "1.0.7-beta6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@compassion-technology/serverless-vpc-plugin",
-      "version": "1.0.7-beta5",
+      "version": "1.0.7-beta6",
       "license": "MIT",
       "dependencies": {
         "cidr-split": "0.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta7",
+  "version": "1.0.7-beta8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@compassion-technology/serverless-vpc-plugin",
-      "version": "1.0.7-beta7",
+      "version": "1.0.7-beta8",
       "license": "MIT",
       "dependencies": {
         "cidr-split": "0.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta3",
+  "version": "1.0.7-beta4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@compassion-technology/serverless-vpc-plugin",
-      "version": "1.0.7-beta3",
+      "version": "1.0.7-beta4",
       "license": "MIT",
       "dependencies": {
         "cidr-split": "0.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta10",
+  "version": "1.0.7-beta11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@compassion-technology/serverless-vpc-plugin",
-      "version": "1.0.7-beta10",
+      "version": "1.0.7-beta11",
       "license": "MIT",
       "dependencies": {
         "cidr-split": "0.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta12",
+  "version": "1.0.7-beta13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@compassion-technology/serverless-vpc-plugin",
-      "version": "1.0.7-beta12",
+      "version": "1.0.7-beta13",
       "license": "MIT",
       "dependencies": {
         "cidr-split": "0.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta6",
+  "version": "1.0.7-beta7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@compassion-technology/serverless-vpc-plugin",
-      "version": "1.0.7-beta6",
+      "version": "1.0.7-beta7",
       "license": "MIT",
       "dependencies": {
         "cidr-split": "0.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,28 +1,28 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7",
+  "version": "1.1.0-beta1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@compassion-technology/serverless-vpc-plugin",
-      "version": "1.0.7",
+      "version": "1.1.0-beta1",
       "license": "MIT",
       "dependencies": {
         "cidr-split": "0.1.2"
       },
       "devDependencies": {
         "aws-sdk-mock": "5.8.0",
-        "eslint": "8.56.0",
+        "eslint": "^8.51.0",
         "eslint-config-airbnb-base": "15.0.0",
-        "eslint-config-prettier": "9.1.0",
-        "eslint-plugin-import": "2.29.1",
-        "eslint-plugin-jest": "27.2.3",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-import": "^2.27.5",
+        "eslint-plugin-jest": "^27.2.3",
         "eslint-plugin-prettier": "5.0.1",
-        "jest": "29.6.2",
-        "nock": "13.3.4",
-        "prettier": "3.0.1",
-        "serverless": "3.38.0"
+        "jest": "^29.6.2",
+        "nock": "^13.3.4",
+        "prettier": "^3.0.1",
+        "serverless": "^3.34.0"
       },
       "engines": {
         "node": ">=12.0"
@@ -5564,9 +5564,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
-      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
+      "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7.beta1",
+  "version": "1.0.7-beta3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@compassion-technology/serverless-vpc-plugin",
-      "version": "1.0.7.beta1",
+      "version": "1.0.7-beta3",
       "license": "MIT",
       "dependencies": {
         "cidr-split": "0.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta11",
+  "version": "1.0.7-beta12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@compassion-technology/serverless-vpc-plugin",
-      "version": "1.0.7-beta11",
+      "version": "1.0.7-beta12",
       "license": "MIT",
       "dependencies": {
         "cidr-split": "0.1.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta7",
+  "version": "1.0.7-beta8",
   "engines": {
     "node": ">=12.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta10",
+  "version": "1.0.7-beta11",
   "engines": {
     "node": ">=12.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta5",
+  "version": "1.0.7-beta6",
   "engines": {
     "node": ">=12.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7",
+  "version": "1.1.0-beta1",
   "engines": {
     "node": ">=12.0"
   },
@@ -30,15 +30,15 @@
   },
   "devDependencies": {
     "aws-sdk-mock": "5.8.0",
-    "eslint": "8.56.0",
+    "eslint": "^8.51.0",
     "eslint-config-airbnb-base": "15.0.0",
-    "eslint-config-prettier": "9.1.0",
-    "eslint-plugin-import": "2.29.1",
-    "eslint-plugin-jest": "27.2.3",
+    "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-jest": "^27.2.3",
     "eslint-plugin-prettier": "5.0.1",
-    "jest": "29.6.2",
-    "nock": "13.3.4",
-    "prettier": "3.0.1",
-    "serverless": "3.38.0"
+    "jest": "^29.6.2",
+    "nock": "^13.3.4",
+    "prettier": "^3.0.1",
+    "serverless": "^3.34.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta4",
+  "version": "1.0.7-beta5",
   "engines": {
     "node": ">=12.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta13",
+  "version": "1.0.7-beta14",
   "engines": {
     "node": ">=12.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta11",
+  "version": "1.0.7-beta12",
   "engines": {
     "node": ">=12.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta12",
+  "version": "1.0.7-beta13",
   "engines": {
     "node": ">=12.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta14",
+  "version": "1.0.7-beta15",
   "engines": {
     "node": ">=12.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta8",
+  "version": "1.0.7-beta9",
   "engines": {
     "node": ">=12.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta9",
+  "version": "1.0.7-beta10",
   "engines": {
     "node": ">=12.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta3",
+  "version": "1.0.7-beta4",
   "engines": {
     "node": ">=12.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta6",
+  "version": "1.0.7-beta7",
   "engines": {
     "node": ">=12.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7-beta15",
+  "version": "1.0.7",
   "engines": {
     "node": ">=12.0"
   },
@@ -9,7 +9,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/compassion-technology/serverless-vpc-plugin"
+    "url": "https://github.com/compassion-technology/serverless-vpc-plugin.git"
   },
   "keywords": [
     "serverless",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7.beta1",
+  "version": "1.0.7-beta3",
   "engines": {
     "node": ">=12.0"
   },

--- a/src/bastion.js
+++ b/src/bastion.js
@@ -140,11 +140,6 @@ function buildBastionLaunchTemplate(keyPairName, { name = 'BastionLaunchTemplate
             Ref: 'LatestAmiId',
           },
           InstanceType: 't2.micro',
-          SecurityGroups: [
-            {
-              Ref: 'BastionSecurityGroup',
-            },
-          ],
           KeyName: keyPairName,
           NetworkInterfaces: [
             {

--- a/src/bastion.js
+++ b/src/bastion.js
@@ -130,44 +130,44 @@ function buildBastionLaunchConfiguration(
           // eslint-disable-next-line no-template-curly-in-string
           'Fn::Sub': '${AWS::StackName}-bastion',
         },
-      },
-      LaunchTemplateData: {
-        IamInstanceProfile: {
-          Arn: {
-            'Fn::GetAtt': ['BastionInstanceProfile', 'Arn'],
-          },
-          ImageId: {
-            Ref: 'LatestAmiId',
-          },
-          InstanceType: 't2.micro',
-          SecurityGroups: [
-            {
-              Ref: 'BastionSecurityGroup',
+        LaunchTemplateData: {
+          IamInstanceProfile: {
+            Arn: {
+              'Fn::GetAtt': ['BastionInstanceProfile', 'Arn'],
             },
-          ],
-          KeyName: keyPairName,
-          NetworkInterfaces: [
-            {
-              AssociatePublicIpAddress: true,
-              DeviceIndex: 0,
-              Groups: [
-                {
-                  Ref: 'BastionSecurityGroup',
-                },
-              ],
-              DeleteOnTermination: true,
+            ImageId: {
+              Ref: 'LatestAmiId',
             },
-          ],
-          BlockDeviceMappings: [
-            {
-              DeviceName: '/dev/xvda',
-              Ebs: {
-                VolumeSize: 10,
-                VolumeType: 'gp3',
+            InstanceType: 't2.micro',
+            SecurityGroups: [
+              {
+                Ref: 'BastionSecurityGroup',
+              },
+            ],
+            KeyName: keyPairName,
+            NetworkInterfaces: [
+              {
+                AssociatePublicIpAddress: true,
+                DeviceIndex: 0,
+                Groups: [
+                  {
+                    Ref: 'BastionSecurityGroup',
+                  },
+                ],
                 DeleteOnTermination: true,
               },
-            },
-          ],
+            ],
+            BlockDeviceMappings: [
+              {
+                DeviceName: '/dev/xvda',
+                Ebs: {
+                  VolumeSize: 10,
+                  VolumeType: 'gp3',
+                  DeleteOnTermination: true,
+                },
+              },
+            ],
+          },
         },
 
         // On-Demand price of t2.micro in us-east-1 (https://aws.amazon.com/ec2/pricing/on-demand/)

--- a/src/bastion.js
+++ b/src/bastion.js
@@ -228,8 +228,13 @@ function buildBastionAutoScalingGroup(numZones = 0, { name = 'BastionAutoScaling
         },
       },
       Properties: {
-        LaunchConfigurationName: {
-          Ref: 'BastionLaunchConfiguration',
+        LaunchTemplate: {
+          LaunchTemplateId: {
+            Ref: 'BastionLaunchConfiguration',
+          },
+          Version: {
+            'Fn::GetAtt': ['BastionLaunchConfiguration', 'LatestVersionNumber'],
+          },
         },
         VPCZoneIdentifier: zones,
         MinSize: 1,

--- a/src/bastion.js
+++ b/src/bastion.js
@@ -120,8 +120,6 @@ function buildBastionInstanceProfile({ name = 'BastionInstanceProfile' } = {}) {
  */
 function buildBastionLaunchTemplate(keyPairName, { name = 'BastionLaunchTemplate' } = {}) {
   // print function args out
-  console.log('using keyPairName for BastionLaunchTemplate', keyPairName);
-  console.log('using name for BastionLaunchTemplate', name);
   return {
     [name]: {
       Type: 'AWS::EC2::LaunchTemplate',

--- a/src/bastion.js
+++ b/src/bastion.js
@@ -122,6 +122,7 @@ function buildBastionLaunchConfiguration(
   keyPairName,
   { name = 'BastionLaunchConfiguration' } = {},
 ) {
+  console.log('using name for BastionLaunchConfiguration', name);
   return {
     [name]: {
       Type: 'AWS::EC2::LaunchTemplate',

--- a/src/bastion.js
+++ b/src/bastion.js
@@ -119,7 +119,6 @@ function buildBastionInstanceProfile({ name = 'BastionInstanceProfile' } = {}) {
  * @return {Object}
  */
 function buildBastionLaunchTemplate(keyPairName, { name = 'BastionLaunchTemplate' } = {}) {
-  // print function args out
   return {
     [name]: {
       Type: 'AWS::EC2::LaunchTemplate',

--- a/src/bastion.js
+++ b/src/bastion.js
@@ -112,17 +112,16 @@ function buildBastionInstanceProfile({ name = 'BastionInstanceProfile' } = {}) {
 }
 
 /**
- * Build the auto-scaling group launch configuration for the bastion host
+ * Build the auto-scaling group launch template for the bastion host
  *
  * @param {String} keyPairName Existing key pair name
  * @param {Object} params
  * @return {Object}
  */
-function buildBastionLaunchConfiguration(
-  keyPairName,
-  { name = 'BastionLaunchConfiguration' } = {},
-) {
-  console.log('using name for BastionLaunchConfiguration', name);
+function buildBastionLaunchTemplate(keyPairName, { name = 'BastionLaunchTemplate' } = {}) {
+  // print function args out
+  console.log('using keyPairName for BastionLaunchTemplate', keyPairName);
+  console.log('using name for BastionLaunchTemplate', name);
   return {
     [name]: {
       Type: 'AWS::EC2::LaunchTemplate',
@@ -231,10 +230,10 @@ function buildBastionAutoScalingGroup(numZones = 0, { name = 'BastionAutoScaling
       Properties: {
         LaunchTemplate: {
           LaunchTemplateId: {
-            Ref: 'BastionLaunchConfiguration',
+            Ref: 'BastionLaunchTemplate',
           },
           Version: {
-            'Fn::GetAtt': ['BastionLaunchConfiguration', 'LatestVersionNumber'],
+            'Fn::GetAtt': ['BastionLaunchTemplate', 'LatestVersionNumber'],
           },
         },
         VPCZoneIdentifier: zones,
@@ -329,7 +328,7 @@ async function buildBastion(keyPairName, numZones = 0) {
     ...buildBastionIamRole(),
     ...buildBastionInstanceProfile(),
     ...buildBastionSecurityGroup(publicIp),
-    ...buildBastionLaunchConfiguration(keyPairName),
+    ...buildBastionLaunchTemplate(keyPairName),
     ...buildBastionAutoScalingGroup(numZones),
   };
 }
@@ -341,6 +340,6 @@ module.exports = {
   buildBastionEIP,
   buildBastionIamRole,
   buildBastionInstanceProfile,
-  buildBastionLaunchConfiguration,
+  buildBastionLaunchTemplate,
   buildBastionSecurityGroup,
 };

--- a/src/nat_instance.js
+++ b/src/nat_instance.js
@@ -68,11 +68,12 @@ function buildNatSecurityGroup() {
  * Build the NAT instance
  *
  * @param {Object} imageId AMI image ID
+ * @param {String} instance type
  * @param {Array} zones Array of availability zones
  * @param {Object} params
  * @return {Object}
  */
-function buildNatInstance(imageId, zones = [], { name = 'NatInstance' } = {}) {
+function buildNatInstance(imageId, instanceType, zones = [], { name = 'NatInstance' } = {}) {
   if (!imageId) {
     return {};
   }
@@ -99,7 +100,7 @@ function buildNatInstance(imageId, zones = [], { name = 'NatInstance' } = {}) {
           },
         ],
         ImageId: imageId, // amzn-ami-vpc-nat-hvm-2018.03.0.20181116-x86_64-ebs
-        InstanceType: 't2.micro',
+        InstanceType: instanceType,
         Monitoring: false,
         NetworkInterfaces: [
           {


### PR DESCRIPTION
Move from using Launch config to launch template. 

I've tested this in dev and it seems to work well. I removed the `SpotPrice` config  because in the upgrade guide it said: 
> If the SpotPrice property is present in your launch configuration, we recommend that you omit it from your launch template. Your Spot Instances will launch at the current Spot price. This price will never exceed the On-Demand price.

This is the change I'm referring to: 
![image](https://github.com/compassion-technology/serverless-vpc-plugin/assets/2174747/36d872da-f72d-426d-9bea-fa032b03a4ab)


and keeping it in requires a bunch more config so I'm hoping we can roll with it like this. This is the migration guide I used: https://docs.aws.amazon.com/autoscaling/ec2/userguide/migrate-launch-configurations-with-cloudformation.html


This is the specific one I created and tested with: 
![image](https://github.com/compassion-technology/serverless-vpc-plugin/assets/2174747/d68a5b68-e5ef-42bc-8d63-ffa97a446154)
