### PR TITLE
feat: use fck-nat

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ custom:
 
     # Whether to create a NAT instance
     createNatInstance: false
+    # When enabled with the above, it will utilize the
+    # [fck-nat](https://fck-nat.dev/) AMI vs. the Amazon AMI's with arm64
+    # t4g.nano instances
+    createNatInstanceFckNat: false
 
     # Whether to create AWS Systems Manager (SSM) Parameters
     createParameters: false

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -247,7 +247,7 @@ describe('ServerlessVpcPlugin', () => {
 
       mockHelper('EC2', 'describeImages', mockCallback);
 
-      const actual = await plugin.getImagesByName('test');
+      const actual = await plugin.getImagesByName('test', 'test', 'test');
       expect(actual).toEqual(['ami-test']);
       expect(mockCallback).toHaveBeenCalled();
       expect.assertions(3);

--- a/__tests__/nat_instance.test.js
+++ b/__tests__/nat_instance.test.js
@@ -121,7 +121,68 @@ describe('nat_instance', () => {
 
       const imageId = 'ami-00a9d4a05375b2763';
 
-      const actual = buildNatInstance(imageId, ['us-east-1a', 'us-east-1b']);
+      const actual = buildNatInstance(imageId, 't2.micro', ['us-east-1a', 'us-east-1b']);
+      expect(actual).toEqual(expected);
+      expect.assertions(1);
+    });
+  });
+
+  describe('#buildNatInstance createNatInstanceFckNat', () => {
+    it('builds an EC2 instance', () => {
+      const expected = {
+        NatInstance: {
+          Type: 'AWS::EC2::Instance',
+          DependsOn: 'InternetGatewayAttachment',
+          Properties: {
+            AvailabilityZone: {
+              'Fn::Select': ['0', ['us-east-1a', 'us-east-1b']],
+            },
+            BlockDeviceMappings: [
+              {
+                DeviceName: '/dev/xvda',
+                Ebs: {
+                  VolumeSize: 10,
+                  VolumeType: 'gp2',
+                  DeleteOnTermination: true,
+                },
+              },
+            ],
+            ImageId: 'ami-0d30a34832b46dcae',
+            InstanceType: 't4g.nano',
+            Monitoring: false,
+            NetworkInterfaces: [
+              {
+                AssociatePublicIpAddress: true,
+                DeleteOnTermination: true,
+                Description: 'eth0',
+                DeviceIndex: '0',
+                GroupSet: [
+                  {
+                    Ref: 'NatSecurityGroup',
+                  },
+                ],
+                SubnetId: {
+                  Ref: 'PublicSubnet1',
+                },
+              },
+            ],
+            SourceDestCheck: false,
+            Tags: [
+              {
+                Key: 'Name',
+                Value: {
+                  // eslint-disable-next-line no-template-curly-in-string
+                  'Fn::Sub': '${AWS::StackName}-nat',
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      const imageId = 'ami-0d30a34832b46dcae';
+
+      const actual = buildNatInstance(imageId, 't4g.nano', ['us-east-1a', 'us-east-1b']);
       expect(actual).toEqual(expected);
       expect.assertions(1);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7",
+  "version": "1.1.0-beta1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@compassion-technology/serverless-vpc-plugin",
-      "version": "1.0.7",
+      "version": "1.1.0-beta1",
       "license": "MIT",
       "dependencies": {
         "cidr-split": "0.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,16 +13,16 @@
       },
       "devDependencies": {
         "aws-sdk-mock": "5.8.0",
-        "eslint": "8.56.0",
+        "eslint": "^8.51.0",
         "eslint-config-airbnb-base": "15.0.0",
-        "eslint-config-prettier": "9.1.0",
-        "eslint-plugin-import": "2.29.1",
-        "eslint-plugin-jest": "27.2.3",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-import": "^2.27.5",
+        "eslint-plugin-jest": "^27.2.3",
         "eslint-plugin-prettier": "5.0.1",
-        "jest": "29.6.2",
-        "nock": "13.3.4",
-        "prettier": "3.0.1",
-        "serverless": "3.38.0"
+        "jest": "^29.6.2",
+        "nock": "^13.3.4",
+        "prettier": "^3.0.1",
+        "serverless": "^3.34.0"
       },
       "engines": {
         "node": ">=12.0"
@@ -5564,9 +5564,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
-      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
+      "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -30,15 +30,15 @@
   },
   "devDependencies": {
     "aws-sdk-mock": "5.8.0",
-    "eslint": "8.56.0",
+    "eslint": "^8.51.0",
     "eslint-config-airbnb-base": "15.0.0",
-    "eslint-config-prettier": "9.1.0",
-    "eslint-plugin-import": "2.29.1",
-    "eslint-plugin-jest": "27.2.3",
+    "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-jest": "^27.2.3",
     "eslint-plugin-prettier": "5.0.1",
-    "jest": "29.6.2",
-    "nock": "13.3.4",
-    "prettier": "3.0.1",
-    "serverless": "3.38.0"
+    "jest": "^29.6.2",
+    "nock": "^13.3.4",
+    "prettier": "^3.0.1",
+    "serverless": "^3.34.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassion-technology/serverless-vpc-plugin",
-  "version": "1.0.7",
+  "version": "1.1.0-beta1",
   "engines": {
     "node": ">=12.0"
   },

--- a/src/nat_instance.js
+++ b/src/nat_instance.js
@@ -68,11 +68,12 @@ function buildNatSecurityGroup() {
  * Build the NAT instance
  *
  * @param {Object} imageId AMI image ID
+ * @param {String} instance type
  * @param {Array} zones Array of availability zones
  * @param {Object} params
  * @return {Object}
  */
-function buildNatInstance(imageId, zones = [], { name = 'NatInstance' } = {}) {
+function buildNatInstance(imageId, instanceType, zones = [], { name = 'NatInstance' } = {}) {
   if (!imageId) {
     return {};
   }
@@ -99,7 +100,7 @@ function buildNatInstance(imageId, zones = [], { name = 'NatInstance' } = {}) {
           },
         ],
         ImageId: imageId, // amzn-ami-vpc-nat-hvm-2018.03.0.20181116-x86_64-ebs
-        InstanceType: 't2.micro',
+        InstanceType: instanceType,
         Monitoring: false,
         NetworkInterfaces: [
           {


### PR DESCRIPTION
This closes https://github.com/compassion-technology/sls-prisma-js/issues/18

Original PR in the original repo: https://github.com/smoketurner/serverless-vpc-plugin/pull/1195/files

To test this, Travis suggested I also verify that lambda can connect to the public internet so I did that along with the same tests I did for the Launch template changes.

In order to use the new fck-nat ami I just added this to the `serverless.yml` file: 
```yaml
custom:
  createNatInstanceFckNat:
    dev: true
    stage: true
    prod: false
...
vpcConfig:
    createNatInstanceFckNat: ${self:custom.createNatInstanceFckNat.${env:SHARED_ENV, opt:stage}}

```

here is the ec2 instance it's creating: https://us-east-2.console.aws.amazon.com/ec2/home?region=us-east-2#InstanceDetails:instanceId=i-0400cb942515c526e